### PR TITLE
Fix error in manifest.outlook.xml

### DIFF
--- a/manifest.outlook.xml
+++ b/manifest.outlook.xml
@@ -24,7 +24,7 @@
     <FormSettings>
         <Form xsi:type="ItemRead">
             <DesktopSettings>
-                <SourceLocation DefaultValue="https://localhost:{PORT}/index.html"/>
+                <SourceLocation DefaultValue="https://localhost:{PORT}/taskpane.html"/>
                 <RequestedHeight>250</RequestedHeight>
             </DesktopSettings>
         </Form>


### PR DESCRIPTION
Changing `SourceLocation` to point to `taskpane.html` -- `index.html` is not a valid value, as there is no such file in the project.