### PR TITLE
Update ssoauthhelper.ts

### DIFF
--- a/src/helpers/ssoauthhelper.ts
+++ b/src/helpers/ssoauthhelper.ts
@@ -4,7 +4,7 @@
  */
 
 /* global OfficeRuntime */
-import { dialogFallback } from "./fallbackAuthHelper";
+import { dialogFallback } from "./fallbackauthhelper";
 import * as sso from "office-addin-sso";
 import { writeDataToOfficeDocument } from "./../taskpane/taskpane";
 let retryGetAccessToken = 0;


### PR DESCRIPTION
There is an issue with `npm run build` in environments respecting filename case sensitivity.   To fix the build, all we needed to do was update the `fallbackauthhelper` import.