### PR TITLE
Move manifest image prep from code to webpack

### DIFF
--- a/src/taskpane/excel.ts
+++ b/src/taskpane/excel.ts
@@ -3,15 +3,6 @@
  * See LICENSE in the project root for license information.
  */
 
-// images references in the manifest
-/* eslint-disable no-unused-vars */
-import icon16 from "../../assets/icon-16.png";
-import icon32 from "../../assets/icon-32.png";
-import icon64 from "../../assets/icon-64.png";
-import icon80 from "../../assets/icon-80.png";
-import icon128 from "../../assets/icon-128.png";
-/* eslint-enable no-unused-vars */
-
 /* global $, document, Excel, Office */
 
 import { getGraphData } from "./../helpers/ssoauthhelper";

--- a/src/taskpane/outlook.ts
+++ b/src/taskpane/outlook.ts
@@ -3,15 +3,6 @@
  * See LICENSE in the project root for license information.
  */
 
-// images references in the manifest
-/* eslint-disable no-unused-vars */
-import icon16 from "../../assets/icon-16.png";
-import icon32 from "../../assets/icon-32.png";
-import icon64 from "../../assets/icon-64.png";
-import icon80 from "../../assets/icon-80.png";
-import icon128 from "../../assets/icon-128.png";
-/* eslint-enable no-unused-vars */
-
 /* global $, document, Office */
 
 import { getGraphData } from "./../helpers/ssoauthhelper";

--- a/src/taskpane/powerpoint.ts
+++ b/src/taskpane/powerpoint.ts
@@ -3,15 +3,6 @@
  * See LICENSE in the project root for license information.
  */
 
-// images references in the manifest
-/* eslint-disable no-unused-vars */
-import icon16 from "../../assets/icon-16.png";
-import icon32 from "../../assets/icon-32.png";
-import icon64 from "../../assets/icon-64.png";
-import icon80 from "../../assets/icon-80.png";
-import icon128 from "../../assets/icon-128.png";
-/* eslint-enable no-unused-vars */
-
 /* global $, document, Office */
 
 import { getGraphData } from "./../helpers/ssoauthhelper";

--- a/src/taskpane/word.ts
+++ b/src/taskpane/word.ts
@@ -3,15 +3,6 @@
  * See LICENSE in the project root for license information.
  */
 
-// images references in the manifest
-/* eslint-disable no-unused-vars */
-import icon16 from "../../assets/icon-16.png";
-import icon32 from "../../assets/icon-32.png";
-import icon64 from "../../assets/icon-64.png";
-import icon80 from "../../assets/icon-80.png";
-import icon128 from "../../assets/icon-128.png";
-/* eslint-enable no-unused-vars */
-
 /* global $, document, Office, Word */
 
 import { getGraphData } from "./../helpers/ssoauthhelper";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -79,6 +79,10 @@ module.exports = async (env, options) => {
       new CopyWebpackPlugin({
         patterns: [
           {
+            from: "assets/icon-*",
+            to: "assets/[name][ext][query]",
+          },
+          {
             from: "manifest*.xml",
             to: "[name]." + buildType + "[ext]",
             transform(content) {


### PR DESCRIPTION
Currently there are a bunch of import statements for the icon.png images in the .ts files, but the files and the html don't reference those images at all. The references to them are in the manifest.xml files. Webpack doesn't get the resources referenced in the XML like it does in the typescript, javascript, and html and so those were added so that webpack would have those images in the deployment location.

At first glance it's not clear why the import statements were needed and it caused some challenges when making unit tests. The import statements were modified to allow for the unit tests, but this ended up breaking the manifest references (hidden by cache hits). In order to accommodate the unit tests, make sure the images are there for the manifest, and remove potential code confusion this change moves the responsibility of copying the image files to the webpack config file instead of the code files.