### PR TITLE
Update convert script to include configure-sso change to json manifest

### DIFF
--- a/convertToSingleHost.js
+++ b/convertToSingleHost.js
@@ -207,6 +207,7 @@ async function updatePackageJsonForJSONManifest() {
   content.scripts.start = "office-addin-debugging start manifest.json";
   content.scripts.stop = "office-addin-debugging stop manifest.json";
   content.scripts.validate = "office-addin-manifest validate manifest.json";
+  content.scripts["configure-sso"] = "office-addin-sso configure manifest.json";
 
   // Write updated JSON to file
   await writeFileAsync(packageJson, JSON.stringify(content, null, 2));


### PR DESCRIPTION
Thank you for your pull request!  Please provide the following information.

---

**Change Description**:
The convert script was missing updating the "configure-sso" script in package.json when updating for the json manifest type.

1. **Do these changes impact any *npm scripts* commands (in package.json)?** (e.g., running 'npm run start')
No.

2. **Do these changes impact *VS Code debugging* options (launch.json)?**
No.

3. **Do these changes impact *template output*?** (e.g., add/remove file, update file location, update file contents)
Slightly . . . updates another line in package.json 

4. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
Probably not.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
Ran the convertToSingleHost script locally.  Also ran the configure-sso script on generated project with json extension change.