### PR TITLE
Update autorun-npm-audit-fix workflow

### DIFF
--- a/.github/workflows/autorun-npm-audit-fix.yml
+++ b/.github/workflows/autorun-npm-audit-fix.yml
@@ -15,11 +15,11 @@ jobs:
         working-directory: ./
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '18'
+          node-version: 'lts/*'
       - name: Get whether autorun-npm-audit-fix branch exists
         run: |
           echo "Getting whether autorun-npm-audit-fix branch exists"


### PR DESCRIPTION
Updates the `autorun-npm-audit-fix` workflow to be consistent with the latest version in OfficeDev/Office-Add-in-samples.

## Changes
- `actions/checkout@v4` → `actions/checkout@v6`
- `actions/setup-node@v4` → `actions/setup-node@v6`
- `node-version: '18'` → `node-version: 'lts/*'`